### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ stages:
   - cov
 
 node_js:
-  - '12'
-  - '10'
+  - 'lts/*'
+  - 'node'
 
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ Complex validation of multiaddr can be built using `isIPFS.multiaddr` and  [`maf
 
 ### `isIPFS.multiaddr(addr)`
 
-Returns `true` if the provided `string`, [`Multiaddr`](https://github.com/multiformats/js-multiaddr) or `Buffer` represents a valid multiaddr or `false` otherwise.
+Returns `true` if the provided `string`, [`Multiaddr`](https://github.com/multiformats/js-multiaddr) or `Uint8Array` represents a valid multiaddr or `false` otherwise.
 
 ### `isIPFS.peerMultiaddr(addr)`
 
-Returns `true` if the provided `string`, [`Multiaddr`](https://github.com/multiformats/js-multiaddr) or `Buffer` represents a valid "IPFS Peer" multiaddr (matching [`IPFS` format from `mafmt`](https://github.com/multiformats/js-mafmt#api)) or `false` otherwise.
+Returns `true` if the provided `string`, [`Multiaddr`](https://github.com/multiformats/js-multiaddr) or `Uint8Array` represents a valid "IPFS Peer" multiaddr (matching [`IPFS` format from `mafmt`](https://github.com/multiformats/js-mafmt#api)) or `false` otherwise.
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "buffer": "^5.6.0",
     "cids": "^1.0.0",
     "iso-url": "~0.4.7",
-    "mafmt": "multiformats/js-mafmt#fix/replace-node-buffers-with-uint8arrays",
+    "mafmt": "^8.0.0",
     "multiaddr": "^8.0.0",
     "multibase": "^3.0.0",
     "multihashes": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -42,17 +42,16 @@
   },
   "dependencies": {
     "buffer": "^5.6.0",
-    "cids": "~0.8.0",
+    "cids": "^1.0.0",
     "iso-url": "~0.4.7",
-    "mafmt": "^7.1.0",
-    "multiaddr": "^7.4.3",
-    "multibase": "~0.7.0",
-    "multihashes": "~0.4.19"
+    "mafmt": "multiformats/js-mafmt#fix/replace-node-buffers-with-uint8arrays",
+    "multiaddr": "^8.0.0",
+    "multibase": "^3.0.0",
+    "multihashes": "^3.0.1",
+    "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^21.10.1",
-    "bs58": "^4.0.1",
-    "chai": "^4.2.0",
+    "aegir": "^25.0.0",
     "pre-commit": "^1.2.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "coverage-publish": "aegir coverage --upload"
   },
   "dependencies": {
-    "buffer": "^5.6.0",
     "cids": "^1.0.0",
     "iso-url": "~0.4.7",
     "mafmt": "^8.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const { Buffer } = require('buffer')
 const multihash = require('multihashes')
 const multibase = require('multibase')
 const Multiaddr = require('multiaddr')
 const mafmt = require('mafmt')
 const CID = require('cids')
 const { URL } = require('iso-url')
+const uint8ArrayToString = require('uint8arrays/to-string')
 
 const pathGatewayPattern = /^https?:\/\/[^/]+\/(ip[fn]s)\/([^/?#]+)/
 const pathPattern = /^\/(ip[fn]s)\/([^/?#]+)/
@@ -132,8 +132,8 @@ function isString (input) {
 }
 
 function convertToString (input) {
-  if (Buffer.isBuffer(input)) {
-    return multibase.encode('base58btc', input).toString().slice(1)
+  if (input instanceof Uint8Array) {
+    return uint8ArrayToString(input, 'base58btc')
   }
 
   if (isString(input)) {

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -20,13 +20,13 @@ describe('ipfs cid', () => {
     done()
   })
 
-  it('isIPFS.cid should match a valid CIDv0 (multihash) buffer', (done) => {
+  it('isIPFS.cid should match a valid CIDv0 (multihash) Uint8Array', (done) => {
     const actual = isIPFS.cid(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o', 'base58btc'))
     expect(actual).to.equal(true)
     done()
   })
 
-  it('isIPFS.cid should not match a broken CIDv0 buffer', (done) => {
+  it('isIPFS.cid should not match a broken CIDv0 Uint8Array', (done) => {
     const actual = isIPFS.cid(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE70'))
     expect(actual).to.equal(false)
     done()

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -1,11 +1,10 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
-const base58 = require('bs58')
-const expect = require('chai').expect
+const { expect } = require('aegir/utils/chai')
 const isIPFS = require('../src/index')
 const CID = require('cids')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('ipfs cid', () => {
   it('isIPFS.cid should match a valid CID instance', (done) => {
@@ -22,13 +21,13 @@ describe('ipfs cid', () => {
   })
 
   it('isIPFS.cid should match a valid CIDv0 (multihash) buffer', (done) => {
-    const actual = isIPFS.cid(Buffer.from(base58.decode('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o')))
+    const actual = isIPFS.cid(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o', 'base58btc'))
     expect(actual).to.equal(true)
     done()
   })
 
   it('isIPFS.cid should not match a broken CIDv0 buffer', (done) => {
-    const actual = isIPFS.cid(Buffer.from('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE70'))
+    const actual = isIPFS.cid(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE70'))
     expect(actual).to.equal(false)
     done()
   })

--- a/test/test-multiaddr.spec.js
+++ b/test/test-multiaddr.spec.js
@@ -34,7 +34,7 @@ describe('ipfs multiaddr', () => {
   })
 
   it('isIPFS.multiaddr should not match random Uint8Array', (done) => {
-    const actual = isIPFS.multiaddr(uint8ArrayFromString('randombuffer'))
+    const actual = isIPFS.multiaddr(uint8ArrayFromString('randomUint8Array'))
     expect(actual).to.equal(false)
     done()
   })
@@ -121,7 +121,7 @@ describe('ipfs peerMultiaddr', () => {
   })
 
   it('isIPFS.peerMultiaddr should not match random Uint8Array', (done) => {
-    const actual = isIPFS.peerMultiaddr(uint8ArrayFromString('randombuffer'))
+    const actual = isIPFS.peerMultiaddr(uint8ArrayFromString('randomUint8Array'))
     expect(actual).to.equal(false)
     done()
   })

--- a/test/test-multiaddr.spec.js
+++ b/test/test-multiaddr.spec.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
-const expect = require('chai').expect
+const { expect } = require('aegir/utils/chai')
 const Multiaddr = require('multiaddr')
 const isIPFS = require('../src/index')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('ipfs multiaddr', () => {
   it('isIPFS.multiaddr should match a string with valid ip4 multiaddr', (done) => {
@@ -26,15 +26,15 @@ describe('ipfs multiaddr', () => {
     done()
   })
 
-  it('isIPFS.multiaddr should match a Buffer with multiaddr', (done) => {
+  it('isIPFS.multiaddr should match a Uint8Array with multiaddr', (done) => {
     const ma = new Multiaddr('/ip6/::1/udp/1234/http')
-    const actual = isIPFS.multiaddr(Buffer.from(ma.buffer))
+    const actual = isIPFS.multiaddr(ma.bytes)
     expect(actual).to.equal(true)
     done()
   })
 
-  it('isIPFS.multiaddr should not match random Buffer', (done) => {
-    const actual = isIPFS.multiaddr(Buffer.from('randombuffer'))
+  it('isIPFS.multiaddr should not match random Uint8Array', (done) => {
+    const actual = isIPFS.multiaddr(uint8ArrayFromString('randombuffer'))
     expect(actual).to.equal(false)
     done()
   })
@@ -111,17 +111,17 @@ describe('ipfs peerMultiaddr', () => {
     done()
   })
 
-  it('isIPFS.peerMultiaddr should match a Buffer with multiaddr', (done) => {
+  it('isIPFS.peerMultiaddr should match a Uint8Array with multiaddr', (done) => {
     for (const addr of validPeerMultiaddrs) {
       const ma = new Multiaddr(addr)
-      const actual = isIPFS.peerMultiaddr((Buffer.from(ma.buffer)))
+      const actual = isIPFS.peerMultiaddr(ma.bytes)
       expect(actual, `isIPFS.peerMultiaddr(${addr})`).to.equal(true)
     }
     done()
   })
 
-  it('isIPFS.peerMultiaddr should not match random Buffer', (done) => {
-    const actual = isIPFS.peerMultiaddr(Buffer.from('randombuffer'))
+  it('isIPFS.peerMultiaddr should not match random Uint8Array', (done) => {
+    const actual = isIPFS.peerMultiaddr(uint8ArrayFromString('randombuffer'))
     expect(actual).to.equal(false)
     done()
   })

--- a/test/test-multihash.spec.js
+++ b/test/test-multihash.spec.js
@@ -1,10 +1,9 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
-const base58 = require('bs58')
-const expect = require('chai').expect
+const { expect } = require('aegir/utils/chai')
 const isIPFS = require('../src/index')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('ipfs multihash', () => {
   it('isIPFS.multihash should match a valid multihash', (done) => {
@@ -14,13 +13,13 @@ describe('ipfs multihash', () => {
   })
 
   it('isIPFS.multihash should match a valid multihash buffer', (done) => {
-    const actual = isIPFS.multihash(Buffer.from(base58.decode('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o')))
+    const actual = isIPFS.multihash(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o', 'base58btc'))
     expect(actual).to.equal(true)
     done()
   })
 
   it('isIPFS.multihash should not match a buffer', (done) => {
-    const actual = isIPFS.multihash(Buffer.from('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE70'))
+    const actual = isIPFS.multihash(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE70'))
     expect(actual).to.equal(false)
     done()
   })

--- a/test/test-multihash.spec.js
+++ b/test/test-multihash.spec.js
@@ -12,13 +12,13 @@ describe('ipfs multihash', () => {
     done()
   })
 
-  it('isIPFS.multihash should match a valid multihash buffer', (done) => {
+  it('isIPFS.multihash should match a valid multihash Uint8Array', (done) => {
     const actual = isIPFS.multihash(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o', 'base58btc'))
     expect(actual).to.equal(true)
     done()
   })
 
-  it('isIPFS.multihash should not match a buffer', (done) => {
+  it('isIPFS.multihash should not match a Uint8Array', (done) => {
     const actual = isIPFS.multihash(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE70'))
     expect(actual).to.equal(false)
     done()

--- a/test/test-path.spec.js
+++ b/test/test-path.spec.js
@@ -1,10 +1,9 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
-const base58 = require('bs58')
 const isIPFS = require('../src/index')
-const expect = require('chai').expect
+const { expect } = require('aegir/utils/chai')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('ipfs path', () => {
   it('isIPFS.ipfsPath should match an ipfs path', (done) => {
@@ -37,8 +36,8 @@ describe('ipfs path', () => {
     done()
   })
 
-  it('isIPFS.ipfsPath should not match a buffer data type', (done) => {
-    const actual = isIPFS.ipfsPath(Buffer.from(base58.decode('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o')))
+  it('isIPFS.ipfsPath should not match a Uint8Array data type', (done) => {
+    const actual = isIPFS.ipfsPath(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o', 'base58btc'))
     expect(actual).to.equal(false)
     done()
   })
@@ -67,8 +66,8 @@ describe('ipfs path', () => {
     done()
   })
 
-  it('isIPFS.ipnsPath should not match a buffer data type', (done) => {
-    const actual = isIPFS.ipnsPath(Buffer.from(base58.decode('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o')))
+  it('isIPFS.ipnsPath should not match a Uint8Array data type', (done) => {
+    const actual = isIPFS.ipnsPath(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o', 'base58btc'))
     expect(actual).to.equal(false)
     done()
   })
@@ -97,8 +96,8 @@ describe('ipfs path', () => {
     done()
   })
 
-  it('isIPFS.path should not match a buffer data type', (done) => {
-    const actual = isIPFS.path(Buffer.from(base58.decode('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o')))
+  it('isIPFS.path should not match a Uint8Array data type', (done) => {
+    const actual = isIPFS.path(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o', 'base58btc'))
     expect(actual).to.equal(false)
     done()
   })
@@ -127,8 +126,8 @@ describe('ipfs path', () => {
     done()
   })
 
-  it('isIPFS.urlOrPath should not match a buffer data type', (done) => {
-    const actual = isIPFS.ipfsPath(Buffer.from(base58.decode('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o')))
+  it('isIPFS.urlOrPath should not match a Uint8Array data type', (done) => {
+    const actual = isIPFS.ipfsPath(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o', 'base58btc'))
     expect(actual).to.equal(false)
     done()
   })

--- a/test/test-subdomain.spec.js
+++ b/test/test-subdomain.spec.js
@@ -1,10 +1,9 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
-const base58 = require('bs58')
 const isIPFS = require('../src/index')
-const expect = require('chai').expect
+const { expect } = require('aegir/utils/chai')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('ipfs subdomain', () => {
   it('isIPFS.ipfsSubdomain should match a cidv1b32', (done) => {
@@ -48,8 +47,8 @@ describe('ipfs subdomain', () => {
     done()
   })
 
-  it('isIPFS.ipfsSubdomain should not match a buffer data type', (done) => {
-    const actual = isIPFS.ipfsSubdomain(Buffer.from(base58.decode('QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR')))
+  it('isIPFS.ipfsSubdomain should not match a Uint8Array data type', (done) => {
+    const actual = isIPFS.ipfsSubdomain(uint8ArrayFromString('QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR', 'base58btc'))
     expect(actual).to.equal(false)
     done()
   })
@@ -81,8 +80,8 @@ describe('ipfs subdomain', () => {
     done()
   })
 
-  it('isIPFS.ipnsSubdomain should not match a buffer data type', (done) => {
-    const actual = isIPFS.ipnsSubdomain(Buffer.from(base58.decode('QmNQuBJ8tg4QN6mSLXHekxBbcToPwKxamWNrDdEugxMTDd')))
+  it('isIPFS.ipnsSubdomain should not match a Uint8Array data type', (done) => {
+    const actual = isIPFS.ipnsSubdomain(uint8ArrayFromString('QmNQuBJ8tg4QN6mSLXHekxBbcToPwKxamWNrDdEugxMTDd', 'base58btc'))
     expect(actual).to.equal(false)
     done()
   })
@@ -154,8 +153,8 @@ describe('ipfs subdomain', () => {
     done()
   })
 
-  it('isIPFS.subdomain should not match a buffer data type', (done) => {
-    const actual = isIPFS.subdomain(Buffer.from(base58.decode('QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR')))
+  it('isIPFS.subdomain should not match a Uint8Array data type', (done) => {
+    const actual = isIPFS.subdomain(uint8ArrayFromString('QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR', 'base58btc'))
     expect(actual).to.equal(false)
     done()
   })

--- a/test/test-url.spec.js
+++ b/test/test-url.spec.js
@@ -1,10 +1,9 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
-const base58 = require('bs58')
-const expect = require('chai').expect
+const { expect } = require('aegir/utils/chai')
 const isIPFS = require('../src/index')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('ipfs url', () => {
   it('isIPFS.ipfsUrl should match an ipfs url', (done) => {
@@ -37,8 +36,8 @@ describe('ipfs url', () => {
     done()
   })
 
-  it('isIPFS.ipfsUrl should not match a buffer input', (done) => {
-    const actual = isIPFS.ipfsUrl(Buffer.from(base58.decode('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o')))
+  it('isIPFS.ipfsUrl should not match a Uint8Array input', (done) => {
+    const actual = isIPFS.ipfsUrl(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o', 'base58btc'))
     expect(actual).to.equal(false)
     done()
   })
@@ -67,8 +66,8 @@ describe('ipfs url', () => {
     done()
   })
 
-  it('isIPFS.ipnsUrl should not match a buffer input', (done) => {
-    const actual = isIPFS.ipnsUrl(Buffer.from(base58.decode('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o')))
+  it('isIPFS.ipnsUrl should not match a Uint8Array input', (done) => {
+    const actual = isIPFS.ipnsUrl(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o', 'base58btc'))
     expect(actual).to.equal(false)
     done()
   })
@@ -97,8 +96,8 @@ describe('ipfs url', () => {
     done()
   })
 
-  it('isIPFS.url should not match a buffer input', (done) => {
-    const actual = isIPFS.url(Buffer.from(base58.decode('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o')))
+  it('isIPFS.url should not match a Uint8Array input', (done) => {
+    const actual = isIPFS.url(uint8ArrayFromString('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o', 'base58btc'))
     expect(actual).to.equal(false)
     done()
   })


### PR DESCRIPTION
Swaps use of node Buffers for Uint8Arrays

Depends on:

- [x] https://github.com/multiformats/js-mafmt/pull/59

BREAKING CHANGES:

- This module now only has deps that use Uint8Arrays and not Buffers