### PR TITLE
feat: dnsaddr support in isIPFS.*multiaddr()

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Returns `true` if the provided `string`, [`Multiaddr`](https://github.com/multif
 
 ### `isIPFS.peerMultiaddr(addr)`
 
-Returns `true` if the provided `string`, [`Multiaddr`](https://github.com/multiformats/js-multiaddr) or `Uint8Array` represents a valid "IPFS Peer" multiaddr (matching [`IPFS` format from `mafmt`](https://github.com/multiformats/js-mafmt#api)) or `false` otherwise.
+Returns `true` if the provided `string`, [`Multiaddr`](https://github.com/multiformats/js-multiaddr) or `Uint8Array` represents a valid libp2p peer multiaddr (matching [`P2P` format from `mafmt`](https://github.com/multiformats/js-mafmt#api)) or `false` otherwise.
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -41,16 +41,16 @@
     "coverage-publish": "aegir coverage --upload"
   },
   "dependencies": {
-    "cids": "^1.0.0",
-    "iso-url": "~0.4.7",
-    "mafmt": "^8.0.0",
-    "multiaddr": "^8.0.0",
-    "multibase": "^3.0.0",
+    "cids": "^1.0.2",
+    "iso-url": "^1.0.0",
+    "mafmt": "^8.0.1",
+    "multiaddr": "^8.1.1",
+    "multibase": "^3.0.1",
     "multihashes": "^3.0.1",
     "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^25.0.0",
+    "aegir": "^28.1.0",
     "pre-commit": "^1.2.2"
   },
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ function isMultiaddr (input) {
 }
 
 function isPeerMultiaddr (input) {
-  return isMultiaddr(input) && mafmt.IPFS.matches(input)
+  return isMultiaddr(input) && mafmt.P2P.matches(input)
 }
 
 function isIpfs (input, pattern, protocolMatch = defaultProtocolMatch, hashMatch = defaultHashMath) {

--- a/test/test-multiaddr.spec.js
+++ b/test/test-multiaddr.spec.js
@@ -19,6 +19,12 @@ describe('ipfs multiaddr', () => {
     done()
   })
 
+  it('isIPFS.multiaddr should match a string with valid dnsaddr multiaddr', (done) => {
+    const actual = isIPFS.multiaddr('/dnsaddr/bootstrap.libp2p.io')
+    expect(actual).to.equal(true)
+    done()
+  })
+
   it('isIPFS.multiaddr should match a valid Multiaddr instance', (done) => {
     const ma = new Multiaddr('/ip6/::1/udp/1234/http')
     const actual = isIPFS.multiaddr(ma)
@@ -90,6 +96,7 @@ describe('ipfs peerMultiaddr', () => {
     '/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/ip4/1.2.3.4/tcp/3456/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
+    '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
     '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit',
     '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj'
   ].concat(goodCircuit)


### PR DESCRIPTION
This bumps dependencies to the latest versions including js-multiaddr 8.x which shipped support for resolving `/dnsaddr/` Peer addresses + adds tests for those peer addresses.

We need this to fix https://github.com/ipfs-shipyard/ipfs-webui/issues/1593

