### PR TITLE
feat(subdomain): support inlined DNSLink names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,12 @@ function isIpns (input, pattern, protocolMatch = defaultProtocolMatch, hashMatch
     if (isCID(ipnsId)) return true
     // Check if it looks like FQDN
     try {
+      if (!ipnsId.includes('.') && ipnsId.includes('-')) {
+        // name without tld, assuming its inlined into a single DNS label
+        // (https://github.com/ipfs/in-web-browsers/issues/169)
+        // en-wikipedia--on--ipfs-org → en.wikipedia-on-ipfs.org
+        ipnsId = ipnsId.replace(/--/g, '@').replace(/-/g, '.').replace(/@/g, '-')
+      }
       // URL implementation in web browsers forces lowercase of the hostname
       const { hostname } = new URL(`http://${ipnsId}`) // eslint-disable-line no-new
       // Check if potential FQDN has an explicit TLD

--- a/test/test-subdomain.spec.js
+++ b/test/test-subdomain.spec.js
@@ -110,9 +110,15 @@ describe('ipfs subdomain', () => {
     done()
   })
 
-  it('isIPFS.ipnsSubdomain should not match if *.ipns is not a fqdn with tld', (done) => {
-    const actual = isIPFS.ipnsSubdomain('http://no-fqdn-with-tld.ipns.dweb.link')
+  it('isIPFS.ipnsSubdomain should not match if *.ipns is not a valid hostname', (done) => {
+    const actual = isIPFS.ipnsSubdomain('http://invalid-hostname-.ipns.dweb.link')
     expect(actual).to.equal(false)
+    done()
+  })
+
+  it('isIPFS.ipnsSubdomain should match if *.ipns is FQDN inlined into a single DNS label', (done) => {
+    const actual = isIPFS.ipnsSubdomain('https://en-wikipedia--on--ipfs-org.ipns.dweb.link')
+    expect(actual).to.equal(true)
     done()
   })
 
@@ -148,8 +154,14 @@ describe('ipfs subdomain', () => {
   })
 
   it('isIPFS.subdomain should not match if *.ipns is not libp2pkey nor fqdn', (done) => {
-    const actual = isIPFS.subdomain('http://not-a-cid-or-dnslink.ipns.dweb.link')
+    const actual = isIPFS.subdomain('http://not-a-cid-or-valid-hostname-.ipns.dweb.link')
     expect(actual).to.equal(false)
+    done()
+  })
+
+  it('isIPFS.subdomain should match if *.ipns looks like an inlined DNSLink name', (done) => {
+    const actual = isIPFS.subdomain('http://en-wikipedia--on--ipfs-org.ipns.dweb.link')
+    expect(actual).to.equal(true)
     done()
   })
 


### PR DESCRIPTION
This correctly detects subdomains with DNSLink name inlined into a single DNS label 
- Context: https://github.com/ipfs/in-web-browsers/issues/169
- To be introduced in go-ipfs 0.8.0-rc2 (https://github.com/ipfs/go-ipfs/pull/7847
- Already live on `dweb.link`: https://en-wikipedia--on--ipfs-org.ipns.dweb.link/wiki/
