### PR TITLE
fix(peerMultiaddr): require /p2p/{key}

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ isIPFS.peerMultiaddr('/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4') // t
 isIPFS.peerMultiaddr('/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4') // true (legacy notation)
 isIPFS.peerMultiaddr('/ip4/127.0.0.1/tcp/1234/ws/p2p/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj') // true
 isIPFS.peerMultiaddr('/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit/p2p/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj') // true
-isIPFS.peerMultiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN') // true
-isIPFS.peerMultiaddr('/dnsaddr/bootstrap.libp2p.io') // true (key resolved via DNS)
+isIPFS.peerMultiaddr('/dnsaddr/bootstrap.libp2p.io') // false (key missing, needs additional DNS lookup to tell if this is valid)
+isIPFS.peerMultiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN') // true (key present, ip and port can be resolved later)
 isIPFS.peerMultiaddr('/ip4/127.0.0.1/udp/1234') // false (key missing)
 ```
 
@@ -219,7 +219,7 @@ Returns `true` if the provided `string`, [`Multiaddr`](https://github.com/multif
 
 ### `isIPFS.peerMultiaddr(addr)`
 
-Returns `true` if the provided `string`, [`Multiaddr`](https://github.com/multiformats/js-multiaddr) or `Uint8Array` represents a valid libp2p peer multiaddr (matching [`P2P` or `DNS` format from `mafmt`](https://github.com/multiformats/js-mafmt#api)) or `false` otherwise.
+Returns `true` if the provided `string`, [`Multiaddr`](https://github.com/multiformats/js-multiaddr) or `Uint8Array` represents a valid libp2p peer multiaddr (matching [`P2P` format from `mafmt`](https://github.com/multiformats/js-mafmt#api)) or `false` otherwise.
 
 # License
 

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ function isMultiaddr (input) {
  * @param {string | Uint8Array | Multiaddr} input
  */
 function isPeerMultiaddr (input) {
-  return isMultiaddr(input) && (mafmt.P2P.matches(input) || mafmt.DNS.matches(input))
+  return isMultiaddr(input) && mafmt.P2P.matches(input)
 }
 
 /**

--- a/test/test-multiaddr.spec.js
+++ b/test/test-multiaddr.spec.js
@@ -103,7 +103,6 @@ describe('ipfs peerMultiaddr', () => {
     '/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/ip4/1.2.3.4/tcp/3456/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
-    '/dnsaddr/bootstrap.libp2p.io',
     '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit',
     '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj'
   ].concat(goodCircuit)
@@ -142,6 +141,13 @@ describe('ipfs peerMultiaddr', () => {
 
   it('isIPFS.peerMultiaddr should not match an invalid multiaddr (no initial slash)', (done) => {
     const actual = isIPFS.peerMultiaddr('ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4')
+    expect(actual).to.equal(false)
+    done()
+  })
+
+  it('isIPFS.peerMultiaddr should not match /dnsaddr multiaddr without explicit /p2p/{key}', (done) => {
+    // https://github.com/ipfs-shipyard/is-ipfs/issues/38
+    const actual = isIPFS.peerMultiaddr('/dnsaddr/bootstrap.libp2p.io')
     expect(actual).to.equal(false)
     done()
   })


### PR DESCRIPTION
BREAKING CHANGE: `/dnsaddr` without explicit `/p2p/{key}` is no longer a valid peer multiaddr. See https://github.com/ipfs-shipyard/is-ipfs/issues/38 for rationale why.

Closes #38